### PR TITLE
Reverse beacon sorting

### DIFF
--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/IndoorPositioning.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/IndoorPositioning.java
@@ -89,7 +89,7 @@ public class IndoorPositioning implements LocationProvider, BeaconUpdateListener
         if (usableBeacons.size() < MINIMUM_BEACON_COUNT) {
             return;
         } else if (usableBeacons.size() > MINIMUM_BEACON_COUNT) {
-            Collections.sort(usableBeacons, Beacon.RssiComparator);
+            Collections.sort(usableBeacons, Beacon.RssiHighToLowComparator);
             int maximumBeaconIndex = Math.min(MAXIMUM_BEACON_COUNT, usableBeacons.size());
             int firstRemovableBeaconIndex = maximumBeaconIndex;
             for (int beaconIndex = MINIMUM_BEACON_COUNT; beaconIndex < maximumBeaconIndex; beaconIndex++) {

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/IndoorPositioning.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/IndoorPositioning.java
@@ -3,6 +3,7 @@ package com.nexenio.bleindoorpositioning;
 import com.nexenio.bleindoorpositioning.ble.beacon.Beacon;
 import com.nexenio.bleindoorpositioning.ble.beacon.BeaconManager;
 import com.nexenio.bleindoorpositioning.ble.beacon.BeaconUpdateListener;
+import com.nexenio.bleindoorpositioning.ble.beacon.BeaconUtil;
 import com.nexenio.bleindoorpositioning.ble.beacon.filter.BeaconFilter;
 import com.nexenio.bleindoorpositioning.ble.beacon.filter.GenericBeaconFilter;
 import com.nexenio.bleindoorpositioning.location.Location;
@@ -89,7 +90,7 @@ public class IndoorPositioning implements LocationProvider, BeaconUpdateListener
         if (usableBeacons.size() < MINIMUM_BEACON_COUNT) {
             return;
         } else if (usableBeacons.size() > MINIMUM_BEACON_COUNT) {
-            Collections.sort(usableBeacons, Beacon.RssiHighToLowComparator);
+            Collections.sort(usableBeacons, BeaconUtil.DescendingRssiComparator);
             int maximumBeaconIndex = Math.min(MAXIMUM_BEACON_COUNT, usableBeacons.size());
             int firstRemovableBeaconIndex = maximumBeaconIndex;
             for (int beaconIndex = MINIMUM_BEACON_COUNT; beaconIndex < maximumBeaconIndex; beaconIndex++) {

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -219,12 +219,27 @@ public abstract class Beacon<P extends AdvertisingPacket> {
         return new KalmanFilter(getLatestTimestamp());
     }
 
+    /**
+     * RssiComparator is deprecated because its name is unintuitive with the sorting it provides.
+     * RssiLowToHighComparator has the same functionality, sorting beacons from lowest rssi to highest rssi.
+      */
+    @Deprecated
     public static Comparator<Beacon> RssiComparator = new Comparator<Beacon>() {
+        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
+            return firstBeacon.rssi - secondBeacon.rssi;
+        }
+    };
 
+    public static Comparator<Beacon> RssiHighToLowComparator = new Comparator<Beacon>() {
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
             return secondBeacon.rssi - firstBeacon.rssi;
         }
+    };
 
+    public static Comparator<Beacon> RssiLowToHighComparator = new Comparator<Beacon>() {
+        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
+            return firstBeacon.rssi - secondBeacon.rssi;
+        }
     };
 
     /*

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -220,23 +220,11 @@ public abstract class Beacon<P extends AdvertisingPacket> {
     }
 
     /**
-     * RssiComparator is deprecated because its name is unintuitive with the sorting it provides.
-     * RssiLowToHighComparator has the same functionality, sorting beacons from lowest rssi to highest rssi.
-      */
+     * This function and its reverse are implemented with indicative naming in BeaconUtil.
+     * @deprecated use {@link BeaconUtil.AscendingRssiComparator} instead
+     */
     @Deprecated
     public static Comparator<Beacon> RssiComparator = new Comparator<Beacon>() {
-        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return firstBeacon.rssi - secondBeacon.rssi;
-        }
-    };
-
-    public static Comparator<Beacon> RssiHighToLowComparator = new Comparator<Beacon>() {
-        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return secondBeacon.rssi - firstBeacon.rssi;
-        }
-    };
-
-    public static Comparator<Beacon> RssiLowToHighComparator = new Comparator<Beacon>() {
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
             return firstBeacon.rssi - secondBeacon.rssi;
         }

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -222,7 +222,7 @@ public abstract class Beacon<P extends AdvertisingPacket> {
     public static Comparator<Beacon> RssiComparator = new Comparator<Beacon>() {
 
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return firstBeacon.rssi - secondBeacon.rssi;
+            return secondBeacon.rssi - firstBeacon.rssi;
         }
 
     };

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconUtil.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconUtil.java
@@ -4,6 +4,7 @@ import com.nexenio.bleindoorpositioning.ble.advertising.AdvertisingPacket;
 import com.nexenio.bleindoorpositioning.ble.beacon.signal.WindowFilter;
 import com.nexenio.bleindoorpositioning.location.distance.BeaconDistanceCalculator;
 
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -154,5 +155,23 @@ public abstract class BeaconUtil {
     public static String getReadableBeaconType(Class<? extends Beacon> beaconClass) {
         return beaconClass.getSimpleName();
     }
+
+    /**
+     * Used to sort beacons from highest rssi to lowest rssi.
+     */
+    public static Comparator<Beacon> DescendingRssiComparator = new Comparator<Beacon>() {
+        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
+            return secondBeacon.rssi - firstBeacon.rssi;
+        }
+    };
+
+    /**
+     * Used to sort beacons from lowest rssi to highest rssi.
+     */
+    public static Comparator<Beacon> AscendingRssiComparator = new Comparator<Beacon>() {
+        public int compare(Beacon firstBeacon, Beacon secondBeacon) {
+            return firstBeacon.rssi - secondBeacon.rssi;
+        }
+    };
 
 }


### PR DESCRIPTION
The beacons were sorted from weakest RSSI to strongest. In IndoorPositioning.updateLocation() this resulted in the strongest beacons being discarded if there existed more than 3 beacons that are below the minimumRssiThreshold.

In commit debc2b0f59caf671bae254245c70ffe250466249 the call to Collections.reverse was, I assume accidentally, removed. Introducing this behaviour. Since beacon sorting isn't used elsewhere I think it's safe to reverse the sorting algorithm, but reintroducing Collections.reverse would also work.