### PR TITLE
Fixed Javadoc @link

### DIFF
--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -221,7 +221,7 @@ public abstract class Beacon<P extends AdvertisingPacket> {
 
     /**
      * This function and its reverse are implemented with indicative naming in BeaconUtil.
-     * @deprecated use {@link BeaconUtil.AscendingRssiComparator} instead
+     * @deprecated use {@link BeaconUtil#AscendingRssiComparator} instead
      */
     @Deprecated
     public static Comparator<Beacon> RssiComparator = new Comparator<Beacon>() {


### PR DESCRIPTION
I just realised it should probably be `@link BeaconUtil#AscendingRssiComparator` instead of `@link BeaconUtil.AscendingRssiComparator` in https://github.com/neXenio/BLE-Indoor-Positioning/pull/145.

https://jitpack.io/com/github/neXenio/BLE-Indoor-Positioning/dev-0.3.0-gc40bef6-230/build.log
`/home/jitpack/build/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java:227: warning - Tag @link: reference not found: BeaconUtil.AscendingRssiComparator`