### PR TITLE
0157 multiple beacon instances

### DIFF
--- a/BLE Indoor Positioning/build.gradle
+++ b/BLE Indoor Positioning/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
 
-def releaseVersionCode = 15
-def releaseVersionName = "0.3.9"
+def releaseVersionCode = 16
+def releaseVersionName = "0.4.0"
 
 def projectName = 'BLE Indoor Positioning'
 def projectDescription = 'Java library for indoor positioing using bluetooth beacons'

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/advertising/AdvertisingPacket.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/advertising/AdvertisingPacket.java
@@ -40,7 +40,11 @@ public abstract class AdvertisingPacket {
 
     @Override
     public String toString() {
-        return AdvertisingPacketUtil.toHexadecimalString(data);
+        return "AdvertisingPacket{" +
+                "data=" + AdvertisingPacketUtil.toHexadecimalString(data) +
+                ", rssi=" + rssi +
+                ", timestamp=" + timestamp +
+                '}';
     }
 
     /*

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/advertising/AdvertisingPacket.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/advertising/AdvertisingPacket.java
@@ -41,7 +41,7 @@ public abstract class AdvertisingPacket {
     @Override
     public String toString() {
         return "AdvertisingPacket{" +
-                "data=" + AdvertisingPacketUtil.toHexadecimalString(data) +
+                "data=" + Arrays.hashCode(data) +
                 ", rssi=" + rssi +
                 ", timestamp=" + timestamp +
                 '}';

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -127,7 +127,7 @@ public abstract class Beacon<P extends AdvertisingPacket> {
                 applyPropertiesFromAdvertisingPacket(advertisingPacket);
             }
 
-            if (latestAdvertisingPacket.getTimestamp() > advertisingPacket.getTimestamp()) {
+            if (latestAdvertisingPacket != null && latestAdvertisingPacket.getTimestamp() > advertisingPacket.getTimestamp()) {
                 return;
             }
 

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/Beacon.java
@@ -15,7 +15,6 @@ import com.nexenio.bleindoorpositioning.location.provider.LocationProvider;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -26,7 +25,6 @@ public abstract class Beacon<P extends AdvertisingPacket> {
 
     public static final long MAXIMUM_PACKET_AGE = TimeUnit.SECONDS.toMillis(60);
 
-    protected UUID uuid;
     protected String macAddress;
     protected int rssi; // in dBm
     protected int calibratedRssi; // in dBm
@@ -76,7 +74,7 @@ public abstract class Beacon<P extends AdvertisingPacket> {
     public abstract BeaconLocationProvider<? extends Beacon> createLocationProvider();
 
     public boolean hasAnyAdvertisingPacket() {
-        return advertisingPackets != null && !advertisingPackets.isEmpty();
+        return !advertisingPackets.isEmpty();
     }
 
     public P getOldestAdvertisingPacket() {
@@ -123,9 +121,16 @@ public abstract class Beacon<P extends AdvertisingPacket> {
     public void addAdvertisingPacket(P advertisingPacket) {
         synchronized (advertisingPackets) {
             rssi = advertisingPacket.getRssi();
-            if (!hasAnyAdvertisingPacket() || !advertisingPacket.dataEquals(getLatestAdvertisingPacket())) {
+
+            P latestAdvertisingPacket = getLatestAdvertisingPacket();
+            if (latestAdvertisingPacket == null || !advertisingPacket.dataEquals(latestAdvertisingPacket)) {
                 applyPropertiesFromAdvertisingPacket(advertisingPacket);
             }
+
+            if (latestAdvertisingPacket.getTimestamp() > advertisingPacket.getTimestamp()) {
+                return;
+            }
+
             advertisingPackets.add(advertisingPacket);
             trimAdvertisingPackets();
             invalidateDistance();
@@ -221,26 +226,34 @@ public abstract class Beacon<P extends AdvertisingPacket> {
 
     /**
      * This function and its reverse are implemented with indicative naming in BeaconUtil.
+     *
      * @deprecated use {@link BeaconUtil#AscendingRssiComparator} instead
      */
     @Deprecated
     public static Comparator<Beacon> RssiComparator = new Comparator<Beacon>() {
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return firstBeacon.rssi - secondBeacon.rssi;
+            if (firstBeacon.equals(secondBeacon)) {
+                return 0;
+            }
+            return Integer.compare(firstBeacon.rssi, secondBeacon.rssi);
         }
     };
+
+    @Override
+    public String toString() {
+        return "Beacon{" +
+                ", macAddress='" + macAddress + '\'' +
+                ", rssi=" + rssi +
+                ", calibratedRssi=" + calibratedRssi +
+                ", calibratedDistance=" + calibratedDistance +
+                ", transmissionPower=" + transmissionPower +
+                ", advertisingPackets=" + advertisingPackets +
+                '}';
+    }
 
     /*
         Getter & Setter
      */
-
-    public UUID getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(UUID uuid) {
-        this.uuid = uuid;
-    }
 
     public String getMacAddress() {
         return macAddress;
@@ -296,4 +309,5 @@ public abstract class Beacon<P extends AdvertisingPacket> {
     public void setLocationProvider(BeaconLocationProvider<? extends Beacon> locationProvider) {
         this.locationProvider = locationProvider;
     }
+
 }

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconManager.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconManager.java
@@ -6,6 +6,7 @@ import com.nexenio.bleindoorpositioning.ble.beacon.signal.MeanFilter;
 import com.nexenio.bleindoorpositioning.ble.beacon.signal.WindowFilter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -126,23 +127,11 @@ public class BeaconManager {
     }
 
     public static String getBeaconKey(String macAddress, AdvertisingPacket advertisingPacket) {
-        return getBeaconKey(macAddress, BeaconUtil.getReadableBeaconType(advertisingPacket));
+        return macAddress + "-" + Arrays.hashCode(advertisingPacket.getData());
     }
 
-    private static String getBeaconKey(String macAddress, String beaconType) {
-        return macAddress + "-" + beaconType;
-    }
-
-    public static IBeacon getIBeacon(String macAddress) {
-        return (IBeacon) getBeacon(macAddress, IBeacon.class);
-    }
-
-    public static Eddystone getEddystone(String macAddress) {
-        return (Eddystone) getBeacon(macAddress, Eddystone.class);
-    }
-
-    public static Beacon getBeacon(String macAddress, Class<? extends Beacon> beaconClass) {
-        String key = getBeaconKey(macAddress, BeaconUtil.getReadableBeaconType(beaconClass));
+    public static Beacon getBeacon(String macAddress, AdvertisingPacket advertisingPacket) {
+        String key = getBeaconKey(macAddress, advertisingPacket);
         return getInstance().beaconMap.get(key);
     }
 

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconUtil.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/BeaconUtil.java
@@ -20,7 +20,7 @@ public abstract class BeaconUtil {
      * @param transmissionPower the tx power (in dBm) of the beacon
      * @return estimated range in meters
      * @see <a href="https://support.kontakt.io/hc/en-gb/articles/201621521-Transmission-power-Range-and-RSSI">Kontakt.io
-     * Knowledge Base</a>
+     *         Knowledge Base</a>
      */
     public static float getAdvertisingRange(int transmissionPower) {
         if (transmissionPower < -30) {
@@ -161,7 +161,10 @@ public abstract class BeaconUtil {
      */
     public static Comparator<Beacon> DescendingRssiComparator = new Comparator<Beacon>() {
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return secondBeacon.rssi - firstBeacon.rssi;
+            if (firstBeacon.equals(secondBeacon)) {
+                return 0;
+            }
+            return Integer.compare(secondBeacon.rssi, firstBeacon.rssi);
         }
     };
 
@@ -170,7 +173,10 @@ public abstract class BeaconUtil {
      */
     public static Comparator<Beacon> AscendingRssiComparator = new Comparator<Beacon>() {
         public int compare(Beacon firstBeacon, Beacon secondBeacon) {
-            return firstBeacon.rssi - secondBeacon.rssi;
+            if (firstBeacon.equals(secondBeacon)) {
+                return 0;
+            }
+            return Integer.compare(firstBeacon.rssi, secondBeacon.rssi);
         }
     };
 

--- a/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/IBeacon.java
+++ b/BLE Indoor Positioning/src/main/java/com/nexenio/bleindoorpositioning/ble/beacon/IBeacon.java
@@ -46,6 +46,20 @@ public class IBeacon<P extends IBeaconAdvertisingPacket> extends Beacon<P> {
         setCalibratedRssi(advertisingPacket.getMeasuredPowerByte());
     }
 
+    @Override
+    public String toString() {
+        return "IBeacon{" +
+                "proximityUuid=" + proximityUuid +
+                ", major=" + major +
+                ", minor=" + minor +
+                ", macAddress='" + macAddress + '\'' +
+                ", rssi=" + rssi +
+                ", calibratedRssi=" + calibratedRssi +
+                ", transmissionPower=" + transmissionPower +
+                ", advertisingPackets=" + advertisingPackets +
+                '}';
+    }
+
     /*
         Getter & Setter
      */

--- a/app/src/main/java/com/nexenio/bleindoorpositioningdemo/bluetooth/BluetoothClient.java
+++ b/app/src/main/java/com/nexenio/bleindoorpositioningdemo/bluetooth/BluetoothClient.java
@@ -5,7 +5,6 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.nexenio.bleindoorpositioning.ble.advertising.AdvertisingPacket;
@@ -18,6 +17,7 @@ import com.polidea.rxandroidble.RxBleClient;
 import com.polidea.rxandroidble.scan.ScanResult;
 import com.polidea.rxandroidble.scan.ScanSettings;
 
+import androidx.annotation.NonNull;
 import rx.Observer;
 import rx.Subscription;
 
@@ -126,7 +126,7 @@ public class BluetoothClient {
         AdvertisingPacket advertisingPacket = BeaconManager.processAdvertisingData(macAddress, data, scanResult.getRssi());
 
         if (advertisingPacket != null) {
-            Beacon beacon = BeaconManager.getBeacon(macAddress, advertisingPacket.getBeaconClass());
+            Beacon beacon = BeaconManager.getBeacon(macAddress, advertisingPacket);
             if (beacon instanceof IBeacon && !beacon.hasLocation()) {
                 beacon.setLocationProvider(createDebuggingLocationProvider((IBeacon) beacon));
             }


### PR DESCRIPTION
Solves #157 

Breaking changes:
- `BeaconManager` now creates a new beacon instance for distinct advertising packets. If a beacon is configured to advertise 2 different advertising packtes (e.g. two IBeacon frames with differend UUIDs, or one IBeacon and one Eddystone frame), two beacon instances will be created with the same mac address.
- Changed methods to get beacon instances from the `BeaconManager`
  - Added `Beacon getBeacon(String macAddress, AdvertisingPacket advertisingPacket)`
  - Removed `Beacon getBeacon(String macAddress, Class<? extends Beacon> beaconClass)`
  - Removed `IBeacon getIBeacon(String macAddress)`
  - Removed `Eddystone getEddystone(String macAddress)`